### PR TITLE
Remove auto dependency install, move to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ high-level things:
 
 ### Requirements
 
+Package dependencies (names are from dnf/yum):
+  - systemd-ukify
+  - sbsigntools
+  - systemd-boot
+  - openssl
+  - expect
+  - virt-firmware
+  - uki-direct
+  - binutils
+
 This role requires that secure boot be enabled on each host. There are not many reasons to
 use UKIs without secure boot, so this was assumed. If you would like support for unsigned
 UKIs, please submit an issue/PR.

--- a/roles/uki_config/tasks/main.yaml
+++ b/roles/uki_config/tasks/main.yaml
@@ -1,18 +1,3 @@
-- name: Install dependencies
-  become: true
-  block:
-    - name: Install required packages
-      ansible.builtin.dnf:
-        name:
-          - systemd-ukify
-          - sbsigntools
-          - systemd-boot
-          - openssl
-          - expect
-          - virt-firmware
-          - uki-direct
-          - binutils
-
 - name: Gather keys and certificates
   become: true
   block:


### PR DESCRIPTION
### Overview

This commit closes issue #1, where installing dependencies was done in the role itself using DNF. Callers must now install their own dependencies however they see fit.