### PR TITLE
Remove restrictions on initrd generators

### DIFF
--- a/roles/uki_config/meta/argument_specs.yaml
+++ b/roles/uki_config/meta/argument_specs.yaml
@@ -7,8 +7,7 @@ argument_specs:
     options:
       uki_config_initrd_generator:
         type: str
-        choices:
-          - dracut
+        description: The tool kernel-install calls to generate an initramfs.
         default: dracut
 
       uki_config_mok:


### PR DESCRIPTION
This restriction is not really enforced anywhere else, and callers should have control over which tool they use as long as it is supported by their system and kernel-install.